### PR TITLE
Use Redis as a cache store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ fly.toml
 /publish.rb
 /publish_bookmark.rb
 /publish_photo.rb
+/publish_code.rb
+/terminal_render.rb
 instagram_import.rb
 node_modules/*
 .DS_Store
@@ -14,6 +16,8 @@ node_modules/*
 .env.*
 .vimrc.local
 *.dump
+*.rdb
+*.onnx
 Capfile
 config/deploy.rb
 config/deploy/production.rb

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 ruby     3.3.0
 postgres 16.1
 rust     1.74.1
-node     20.10.0
+nodejs   20.10.0
+redis    7.2.4

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "georuby"
 gem "gpx"
 gem "gnuplot"
 gem "matrix"
+gem "redis"
 
 gem "rack-session"
 gem "rack-rewrite"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,10 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
+    redis (5.1.0)
+      redis-client (>= 0.17.0)
+    redis-client (0.21.0)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -562,6 +566,7 @@ DEPENDENCIES
   rack-test
   rake
   redcarpet
+  redis
   reverse_markdown
   rexml
   rom-factory

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec hanami server
 tailwind: bundle exec rake tailwind:watch
 assets: bundle exec hanami assets watch
+redis: redis-server

--- a/app/action.rb
+++ b/app/action.rb
@@ -22,8 +22,8 @@ module Adamantium
     handle_exception ROM::TupleCountMismatchError => :not_found
     handle_exception StandardError => :handle_error
 
-    def cache(key:, content_proc:, expiry: TimeMath.min.advance(Time.now, +10))
-      cacher.call(key: key, content_proc: content_proc, expiry: expiry)
+    def cache(key:, params: [], content_proc:, expiry: TimeMath.min.advance(Time.now, +10))
+      cacher.call(key: key, params: params, content_proc: content_proc, expiry: expiry)
     end
 
     def not_found(_req, res, _exception)

--- a/config/providers/clients.rb
+++ b/config/providers/clients.rb
@@ -4,5 +4,8 @@ Hanami.app.register_provider :clients, namespace: true do
     register "blue_sky", Adamantium::Client::BlueSky.new
     register "omdb", Adamantium::Client::Omdb.new(api_key: target["settings"].omdb_api_key)
     register "gist", Adamantium::Client::Gist.new(token: target["settings"].gist_client_token)
+    
+    require "redis"
+    register "redis", Redis.new
   end
 end

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -4,6 +4,9 @@ require "adamantium/types"
 
 module Adamantium
   class Settings < Hanami::Settings
+    # App Settings
+    setting :cache_store, default: :redis_cache_store
+
     # Infrastructure
     setting :database_url
 

--- a/lib/adamantium/view_cache/file_store.rb
+++ b/lib/adamantium/view_cache/file_store.rb
@@ -1,0 +1,28 @@
+module Adamantium
+  module ViewCache
+    class FileStore
+      def write(key:, content:, expiry:)
+        filename = "#{key}.json"
+        path = File.join(Hanami.app.root, "tmp", filename)
+
+        File.write(path, content)
+      end
+
+      def read(key:)
+        filename = "#{key}.json"
+        path = File.join(Hanami.app.root, "tmp", filename)
+
+        return nil unless File.exist?(path)
+
+        cached_data = JSON.parse(File.read(path))
+
+        if Time.strptime(cached_data["expire"].to_s, "%s") < Time.now
+          File.delete(path)
+          nil
+        else
+          cached_data["content"]
+        end
+      end
+    end
+  end
+end

--- a/lib/adamantium/view_cache/redis_cache_store.rb
+++ b/lib/adamantium/view_cache/redis_cache_store.rb
@@ -1,0 +1,18 @@
+module Adamantium
+  module ViewCache
+    class RedisCacheStore
+      include Deps["clients.redis"]
+
+      def read(key:)
+        cached_data = redis.get(key)
+
+        JSON.parse(cached_data)["content"] if cached_data
+      end
+
+      def write(key:, content:, expiry:)
+        redis.set(key, content, exat: expiry.to_i)
+      end
+    end
+  end
+end
+

--- a/slices/main/actions/posts/index.rb
+++ b/slices/main/actions/posts/index.rb
@@ -6,8 +6,7 @@ module Main
         def handle(req, res)
           res.body = cache(key: "posts_index", 
                            params: [req.params[:q]], 
-                           content_proc: ->(q) { res.render index, query: q }) 
-          res.status = 200
+                           content_proc: ->(q) { index.call(context: Main::Views::Context.new(request: req), query: q) }) 
         end
       end
     end

--- a/slices/main/actions/posts/index.rb
+++ b/slices/main/actions/posts/index.rb
@@ -4,7 +4,10 @@ module Main
       class Index < Action
         include Deps["views.posts.index"]
         def handle(req, res)
-          res.render index, query: req.params[:q]
+          res.body = cache(key: "posts_index", 
+                           params: [req.params[:q]], 
+                           content_proc: ->(q) { res.render index, query: q }) 
+          res.status = 200
         end
       end
     end


### PR DESCRIPTION
This PR introduces Redis as an optional cache backend for Hanami's actions.

The API within an action looks something like:

```ruby
res.body = cache(key: "posts_index", 
                 params: [req.params[:q]], 
                 content_proc: ->(q) { index.call(context: Main::Views::Context.new(request: req), query: q) }) 
```

The context injection is necessary to ensure assets are available. If assets aren't needed, it should be possible to omit specifying a context and instead let Hanami fall back to the default context.

Caching in this site is mostly over kill. There are a couple of calls that take a few seconds as they call out to external server, but overall things are pretty snappy. Using _redis_ as a cache backend is definitely overkill, but something I wanted to experiment with to see what I would take to extend the action caching layer in a small Hanami app.

An API like:

```ruby
res.render view_class, cache: true, param1: "one", param2: "two"
```

Would be a neater API — but some of the control is lost with regard to cache key naming and TTL control.